### PR TITLE
fix: avoid post-Chrome-79 ES builtins that white-screen on old WebViews

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,6 +1,6 @@
-Chrome >=79
-ChromeAndroid >=79
-Firefox >=70
-Edge >=79
-Safari >=14
-iOS >=14
+Chrome >=91
+ChromeAndroid >=91
+Firefox >=91
+Edge >=91
+Safari >=18
+iOS >=18

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -28,8 +28,8 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-    - name: Run ESLint (Core Only)
-      run: npx eslint src/core --ext .ts,.tsx
+    - name: Run ESLint
+      run: npx eslint src --ext .ts,.tsx
 
     - name: Run unit tests
 

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -37,3 +37,15 @@ jobs:
 
     - name: 🔨 Build project
       run: npm run build
+
+    - name: Check bundle ES compatibility (Chrome 91 WebView floor)
+      # Pinned CI-only dependency (no package.json entry) per review consensus.
+      # Floor: es2021 + allowList of ES2022 features Chrome 91 already supports.
+      # Raising the min WebView floor later = delete allowList lines whose
+      # Chrome version is now below the floor.
+      #   PrivateClassFields: Chrome 74 (private methods 84)
+      #   ClassStaticBlocks:  Chrome 91
+      #   ErrorCause:         options arg silently ignored pre-93, degrades gracefully
+      run: >
+        npx es-check@9.6.4 es2021 'build/**/*.js' --checkFeatures
+        --allowList=PrivateClassFields,ClassStaticBlocks,ErrorCause

--- a/src/core/agent/services/keriaNotificationService.ts
+++ b/src/core/agent/services/keriaNotificationService.ts
@@ -960,9 +960,12 @@ class KeriaNotificationService extends AgentService {
     const payload = exchange.exn.a;
 
     const valid = [
-      Object.hasOwn(payload, "m") && typeof payload.m === "string",
-      Object.hasOwn(payload, "t") && typeof payload.t === "string",
-      Object.hasOwn(payload, "st") && typeof payload.st === "string",
+      Object.prototype.hasOwnProperty.call(payload, "m") &&
+        typeof payload.m === "string",
+      Object.prototype.hasOwnProperty.call(payload, "t") &&
+        typeof payload.t === "string",
+      Object.prototype.hasOwnProperty.call(payload, "st") &&
+        typeof payload.st === "string",
       Array.isArray(payload.c) &&
         payload.c.length > 0 &&
         payload.c.every((paragraph: unknown) => typeof paragraph === "string"),

--- a/src/types/es2021-error-cause.d.ts
+++ b/src/types/es2021-error-cause.d.ts
@@ -1,0 +1,13 @@
+// Deliberate exception to the ES2021 lib pin (Chrome 91 WebView floor):
+// `new Error(message, { cause })` is ES2022, but engines without it
+// silently ignore the options argument, so it degrades gracefully
+// instead of crashing. Declaring it locally keeps the 12 intentional
+// call sites compiling without re-enabling the rest of the ES2022 lib.
+interface ErrorOptions {
+  cause?: unknown;
+}
+
+interface ErrorConstructor {
+  new (message?: string, options?: ErrorOptions): Error;
+  (message?: string, options?: ErrorOptions): Error;
+}

--- a/src/ui/components/ProfileDetailsModal/components/IdentifierAttributeDetailModal/IdentifierAttributeDetailModal.tsx
+++ b/src/ui/components/ProfileDetailsModal/components/IdentifierAttributeDetailModal/IdentifierAttributeDetailModal.tsx
@@ -54,7 +54,7 @@ const IdentifierAttributeDetailModal = ({
         isCurrentUser: isCurrent,
         avatar: (
           <MemberAvatar
-            firstLetter={name.at(0)?.toLocaleUpperCase() || ""}
+            firstLetter={name[0]?.toLocaleUpperCase() || ""}
             rank={rank}
           />
         ),

--- a/src/ui/components/ProfileDetailsModal/components/ProfileContent.test.tsx
+++ b/src/ui/components/ProfileDetailsModal/components/ProfileContent.test.tsx
@@ -64,7 +64,7 @@ describe("ProfileContent", () => {
       const { getByTestId } = renderComponent();
 
       expect(getByTestId("avatar-button")).toHaveTextContent(
-        identifierFix[0].displayName.at(0) || ""
+        identifierFix[0].displayName[0] || ""
       );
       expect(getByTestId("edit-button")).toBeInTheDocument();
       expect(getByTestId("share-button")).toBeInTheDocument();

--- a/src/ui/components/ProfileDetailsModal/components/ProfileContent.tsx
+++ b/src/ui/components/ProfileDetailsModal/components/ProfileContent.tsx
@@ -108,7 +108,7 @@ const ProfileContent = ({
         name,
         avatar: (
           <MemberAvatar
-            firstLetter={name.at(0)?.toLocaleUpperCase() || ""}
+            firstLetter={name[0]?.toLocaleUpperCase() || ""}
             rank={rank}
           />
         ),

--- a/src/ui/components/SeedPhraseModule/SeedPhraseModule.tsx
+++ b/src/ui/components/SeedPhraseModule/SeedPhraseModule.tsx
@@ -48,7 +48,7 @@ const SeedPhraseModule = forwardRef<SeedPhraseModuleRef, SeedPhraseModuleProps>(
 
     useImperativeHandle(ref, () => ({
       focusInputByIndex: (index) => {
-        const input = seedInputs.current.at(index);
+        const input = seedInputs.current[index];
         if (!input) return;
 
         (

--- a/src/ui/components/SetGroupUserName/SetGroupUserName.tsx
+++ b/src/ui/components/SetGroupUserName/SetGroupUserName.tsx
@@ -127,7 +127,7 @@ const SetGroupUserName = ({ identifier, onClose }: SetGroupNameProps) => {
         <p className="text">{i18n.t("setgroup.text")}</p>
         <div className="group-info">
           <MemberAvatar
-            firstLetter={identifier.displayName.at(0)?.toUpperCase() || ""}
+            firstLetter={identifier.displayName[0]?.toUpperCase() || ""}
             rank={0}
           />
           <p className="group-name">{identifier.displayName}</p>

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequestInformation/CredentialRequestInformation.tsx
@@ -74,7 +74,7 @@ const CredentialRequestInformation = ({
   const isJoinGroup = linkedGroup?.memberInfos.some(
     (item) => item.aid === userAID && item.joined
   );
-  const groupInitiatorJoined = !!linkedGroup?.memberInfos.at(0)?.joined;
+  const groupInitiatorJoined = !!linkedGroup?.memberInfos[0]?.joined;
   const isMemberPendingState =
     !isGroupInitiator && !groupInitiatorJoined && isGroup;
   const isInitiatorJoined = isGroupInitiator && groupInitiatorJoined;
@@ -373,7 +373,7 @@ const CredentialRequestInformation = ({
             >
               <CardDetailsItem
                 info={
-                  linkedGroup?.memberInfos.at(0)?.name ||
+                  linkedGroup?.memberInfos[0]?.name ||
                   i18n.t("tabs.connections.unknown")
                 }
                 startSlot={<FallbackIcon />}

--- a/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
+++ b/src/ui/pages/NotificationDetails/components/ReceiveCredential/ReceiveCredential.tsx
@@ -328,7 +328,7 @@ const ReceiveCredential = ({
       isCurrentUser: isCurrent,
       avatar: (
         <MemberAvatar
-          firstLetter={name.at(0)?.toLocaleUpperCase() || ""}
+          firstLetter={name[0]?.toLocaleUpperCase() || ""}
           rank={rank}
         />
       ),

--- a/src/ui/pages/SetupGroupProfile/components/InitializeGroup/InitializeGroup.tsx
+++ b/src/ui/pages/SetupGroupProfile/components/InitializeGroup/InitializeGroup.tsx
@@ -83,7 +83,7 @@ const InitializeGroup = ({ state, setState }: StageProps) => {
       ...member,
       avatar: (
         <MemberAvatar
-          firstLetter={member.name.at(0)?.toLocaleUpperCase() || ""}
+          firstLetter={member.name[0]?.toLocaleUpperCase() || ""}
           rank={index >= 0 ? index % 5 : 0}
         />
       ),

--- a/src/ui/pages/SetupGroupProfile/components/PendingGroup/PendingGroup.tsx
+++ b/src/ui/pages/SetupGroupProfile/components/PendingGroup/PendingGroup.tsx
@@ -183,7 +183,7 @@ const PendingGroup = ({ state, isPendingGroup }: StageProps) => {
       ...member,
       avatar: (
         <MemberAvatar
-          firstLetter={member.name.at(0)?.toLocaleUpperCase() || ""}
+          firstLetter={member.name[0]?.toLocaleUpperCase() || ""}
           rank={index >= 0 ? index % 5 : 0}
         />
       ),
@@ -418,7 +418,7 @@ const PendingGroup = ({ state, isPendingGroup }: StageProps) => {
             <CardDetailsItem
               startSlot={
                 <MemberAvatar
-                  firstLetter={intiatorName.at(0)?.toLocaleUpperCase() || ""}
+                  firstLetter={intiatorName[0]?.toLocaleUpperCase() || ""}
                   rank={0}
                 />
               }

--- a/src/ui/pages/SetupGroupProfile/components/SetupConnections/ShareConnections.tsx
+++ b/src/ui/pages/SetupGroupProfile/components/SetupConnections/ShareConnections.tsx
@@ -148,7 +148,7 @@ const ShareConnections = ({ group, oobi, profile }: SetupConnectionsProps) => {
               <IonItem key={connection.id}>
                 <IonLabel className="connection-item">
                   <div className={`connection-avatar rank-${index % 5}`}>
-                    <span>{connection.label.at(0)?.toLocaleUpperCase()}</span>
+                    <span>{connection.label[0]?.toLocaleUpperCase()}</span>
                   </div>
                   <span className="connection-name">{connection.label}</span>
                 </IonLabel>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "target": "es2022",
+    "target": "ES2021",
     "lib": [
       "dom",
       "dom.iterable",
-      "es2022"
+      "ES2021"
     ],
     "allowJs": true,
     "skipLibCheck": true,
@@ -20,6 +20,7 @@
     "jsx": "react-jsx",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    "useDefineForClassFields": true,
     "types": [
       "node",
       "@wdio/globals/types",


### PR DESCRIPTION
Closes #1659

Fixes a white-screen on WebViews older than Chrome 92 (full root cause, repro,
and affected screens in #1659). In short: the bundle ships ES2022 runtime
methods untranspiled — `tsconfig` `target: es2022`, compiled with `ts-loader`
and no Babel/core-js pass over the app bundle (the only polyfill plugin,
`node-polyfill-webpack-plugin`, covers Node core modules, not ES builtins) —
while `.browserslistrc` declares `Chrome >=79`. `Array/String.prototype.at`
(Chrome 92) and `Object.hasOwn` (Chrome 93) throw `TypeError` mid React-render,
and with no error boundary the tree unmounts and the page goes blank.

### Changes
1. Replace the unsupported builtins with floor-safe equivalents (identical
   semantics):
   - 11 × `.at(i)` → bracket indexing `[i]`
   - 3 × `Object.hasOwn(o, k)` → `Object.prototype.hasOwnProperty.call(o, k)`
2. **(Superseded by the rework below.)** Add `eslint-plugin-es-x` in `.eslintrc.json` — a curated rule set matching
   the current `.browserslistrc` floor (`Chrome >=79`), failing lint on the
   runtime builtins newer than it (`at` / `Object.hasOwn` / `replaceAll` /
   `Promise.any` / `findLast` / `toSorted` / `toReversed` / `toSpliced` /
   `with`). Scoped to shipped app source; test files excluded (they run in modern
   jsdom). This is the regression guard for the bug class. (It's a hand-curated
   list, not auto-derived from browserslist — kept in step with the floor by
   hand; the durable, fully-general fix is the build-level change noted below.)
3. Widen the CI ESLint job from `src/core` to `src`. Every offending `.at()` was
   in `src/ui`, which the lint job never checked — so without this the guard
   would not run on the files that actually had the bug (only the local
   pre-commit hook would). ~5s.

### Alternatives considered
- **Polyfill the build (`@babel/preset-env` + core-js, or lower the `tsconfig`
  target):** fixes the whole class at the source, but adds a babel pass + core-js
  weight to the bundle — a larger build change than a shipping white-screen
  hotfix warrants. Worth doing as a follow-up; called out, not bundled here.
- **Bump `.browserslistrc` to `>=92` instead of fixing the code:** if the floor
  (`Chrome/ChromeAndroid >=79`, `Safari/iOS >=14`, `Firefox >=70`) is meant to
  support stale-WebView devices (AOSP / enterprise / offline), fixing the code
  keeps that guarantee. If it's actually movable, lowering the `tsconfig` target
  instead would be the cleaner fix — happy to go that way.
- **`eslint-plugin-compat`:** rejected — it flags Web APIs (e.g. `structuredClone`)
  but misses prototype-method builtins like `.at`, so it would not have caught this.

### Testing
- `npx tsc --noEmit` clean; `npx eslint src --ext .ts,.tsx` clean (guard active;
  verified it errors on a re-introduced `.at()`).
- No unit test added: this is not reproducible in the unit runner — jest runs in
  jsdom on modern Node, where `.at`/`Object.hasOwn` exist natively, so the call
  never throws there (the existing `ProfileContent.test.tsx` even asserts an
  avatar initial via `.at(0)` and passes before & after). The failure is a
  property of the old WebView runtime, not the logic — so the durable regression
  control is the CI lint guard, not a render test.
- Syntactic equivalents on the affected screens (avatar initials, notification
  parsing) — behavior unchanged on supported WebViews.

## Rework 1 (superseded by Rework 2): browserslist-driven guard (review follow-up)

> **Superseded:** `eslint-plugin-ecmascript-compat` turned out to be deprecated on
> npm ("no longer supported") — unacceptable as the guard engine, since the whole
> point was avoiding decaying dependencies. See **Rework 2** for the
> actively-maintained replacement. Kept below for history.

Per review feedback, the manual `eslint-plugin-es-x` rule list is gone. Instead:

- `.browserslistrc` is now the single source of truth. `eslint-plugin-ecmascript-compat` reads it and enables the matching compat rules automatically, so nothing decays when the floor moves - edit one file and the rules follow. (Side benefit: the derived set also covers things the manual list missed, e.g. class static blocks, Chrome 94+.)
- `eslint-webpack-plugin` runs a minimal compat-only ESLint config (`.eslintrc.compat.cjs`) inside `webpack.common.cjs`, so `npm run build` and `npm run dev` fail on any `.browserslistrc` compatibility break.
- Enabling that required moving type checking to `fork-ts-checker-webpack-plugin` with ts-loader in `transpileOnly` mode: ts-loader's in-loader type-check pass rebuilds `compilation.errors` keeping only `webpack.WebpackError` instances ([after-compile.ts](https://github.com/TypeStrong/ts-loader/blob/main/src/after-compile.ts)), which silently drops eslint-webpack-plugin's plain-`Error` reports - the build passed despite violations. The split is the ecosystem-standard setup, and builds got ~40% faster locally. Behavior parity kept: `async: false`, so type errors still fail dev and prod compilations (verified with a deliberate type error). Safe here: `isolatedModules` already on, no const enums, no decorators, and `tsc --noEmit` over the bundled program is clean. Tests are excluded from the type-check program - they were outside ts-loader's module graph before too, and stay type-checked via ts-jest.

*(The "Assumptions to confirm" list now lives after Rework 2 below - those decisions are still current.)*

The white-screen source fixes and the full-repo ESLint run from the original PR are unchanged.

## Rework 2: es-x + target-es (ecmascript-compat was deprecated)

Post-push due diligence found `eslint-plugin-ecmascript-compat` is deprecated on
npm ("no longer supported") — unacceptable as the guard engine, since the whole
point was avoiding decaying dependencies. Reworked onto an actively-maintained
base while keeping `.browserslistrc` as the single source of truth:

- **`eslint-plugin-es-x`** (@eslint-community, the maintained successor to
  `eslint-plugin-es`) provides the rules; **`@automattic/eslint-config-target-es`**
  reads `.browserslistrc` + MDN `browser-compat-data` and auto-activates the
  matching es-x rules. Edit `.browserslistrc`, the rules follow — nothing decays.
- **`builtins` variant** (`.../rc/builtins`): lints only un-transpilable runtime
  builtins (`Array.prototype.at`, `Object.hasOwn`, `findLast`, …) — the class that
  white-screens. Modern *syntax* is left to ts-loader/webpack (it's down-levelled
  at build time), which also drops a top-level-await false positive that the `all`
  variant produced (MDN marks it `partial_implementation` for Safari, treated as
  unsupported).
- `Error.cause` exemption preserved via `es-x/no-error-cause: off`.
- **ESLint version:** stays on ESLint 8. `es-x` pinned `^8` (9.x/10.x require
  ESLint ≥9); `eslint-webpack-plugin` kept at v4 (v6 requires ESLint ≥9).
- `.eslintrc.compat.cjs` (the webpack-guard config) sets an **absolute**
  `parserOptions.project`: es-x prototype-method rules (e.g. `no-array-prototype-at`)
  need type info to fire, and a relative path fails to resolve under
  eslint-webpack-plugin's cwd — which would silently let `.at()` through the build.

**Verified:** both the CI config and the webpack-guard config flag
`Array.prototype.at`, `String.prototype.at`, `Object.hasOwn`, and
`Array.prototype.findLast`, and correctly ignore below-floor `replaceAll`
(Chrome 85). A src file imported into the bundle using `.at()` fails `npm run build`; a clean build
passes (Node 20).

The `fork-ts-checker-webpack-plugin` / `transpileOnly` restructure and the
`.browserslistrc` floor decisions from Rework 1 are unchanged. The node_modules
blind spot (a dependency shipping untranspiled builtins) remains out of scope —
tracked as a follow-up (candidate: a post-build compat gate over the bundle).

## Assumptions to confirm

- `.browserslistrc` floors raised to `Chrome/ChromeAndroid/Firefox/Edge >=91`: minSdk 31 ships base WebView Chrome 91 (where the white screen reproduced); stale `Firefox >=70` / `Edge >=79` would drag the computed ES floor below optional chaining and flag `?.` repo-wide. Happy to drop the Firefox/Edge lines instead - the app only ships in Android WebView / iOS WKWebView.
- `Safari/iOS` raised `>=14` -> `>=18`, matching `IPHONEOS_DEPLOYMENT_TARGET`/Podfile (18.0). Floor 14.0 would flag class fields and top-level await codebase-wide, which current builds can never encounter.
- `Error.cause` (Chrome 93) is exempted via `es-x/no-error-cause: off`: engines without it ignore the options argument silently - graceful degradation, not a crash - and stripping it from 12 call sites would lose diagnostics.
- Guard scope: first-party `src/**/*.{ts,tsx}` only, detection-only (no transpile/polyfill layer), matching the "make webpack complain" suggestion. Bundled `node_modules` code is not compat-checked (see the blind-spot note above); the durable general fix remains a transpile/polyfill layer as a follow-up.


## Rework 3 (current): pinned es-check on the built bundle

Per review consensus (CI-only check, no new package.json dependencies):

- **Removed** both es-x dependencies (`eslint-plugin-es-x`,
  `@automattic/eslint-config-target-es`) and the derived lint config.
  Net new dependencies in this PR: **zero**.
- **CI layer:** one step in `build-test.yaml` after the existing build,
  `npx es-check@9.6.4` (exact pin) scanning `build/**/*.js` - the bundle
  that ships in the APK. This also covers pre-built JS from transitive
  npm dependencies, which no source lint could see.
- **Chrome-91 straddle:** Chrome 91 has ES2022 class syntax but lacks the
  ES2022 builtins, so the floor is `es2021 --checkFeatures` plus an
  allowList of features Chrome 91 already supports. Every allowList entry
  carries a comment with the Chrome version that added it: raising the
  min SDK floor later is a mechanical deletion of the lines below the new
  floor.
- **Dev-time layer (zero deps):** `tsconfig` `target`/`lib` moved to
  ES2021 with a local `.d.ts` shim for `Error` `cause` (silently ignored
  by engines without it, graceful degradation). New `.at`/`hasOwn` usage
  in our own code now fails typecheck and shows as an IDE error before CI.
  `useDefineForClassFields` is pinned to `true` - the ES2021 target would
  otherwise flip its default and change class-field emit from [[Define]]
  to [[Set]] semantics (caught by the unit suite; Chrome 91 supports
  native class fields).
- **Negative test:** verified the CI guard actually fires - injecting an
  `.at()` call into the built bundle makes the step fail naming
  `ArrayPrototypeAt`; note the injection must land on its own line because
  the bundle ends in an unterminated `//# sourceMappingURL` comment.
