### PR TITLE
refactor: remove unused formatLongDate util and its timezone-fragile test

### DIFF
--- a/src/ui/utils/formatters.test.ts
+++ b/src/ui/utils/formatters.test.ts
@@ -2,7 +2,6 @@ import { notificationsFix } from "../__fixtures__/notificationsFix";
 import {
   ellipsisText,
   formatCurrencyUSD,
-  formatLongDate,
   formatShortTime,
   timeDifference,
 } from "./formatters";
@@ -11,12 +10,6 @@ describe("Utils", () => {
   test("formatCurrencyUSD", () => {
     const balance = 1012.0;
     expect(formatCurrencyUSD(balance)).toBe("$1,012.00");
-  });
-
-  test("formatLongDate", () => {
-    expect(formatLongDate("2024-07-16T03:32:59.312000+00:00")).toBe(
-      "16 July 2024"
-    );
   });
 
   test("formatShortTime", () => {

--- a/src/ui/utils/formatters.ts
+++ b/src/ui/utils/formatters.ts
@@ -6,14 +6,6 @@ const formatShortDate = (date: string) => {
   });
 };
 
-const formatLongDate = (date: string) => {
-  return new Date(date).toLocaleDateString("en-GB", {
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
-};
-
 const formatShortTime = (date: string) => {
   return new Date(date).toLocaleTimeString("en-GB", {
     hour: "2-digit",
@@ -95,7 +87,6 @@ function getUTCOffset(value?: Date | string | number) {
 
 export {
   formatShortDate,
-  formatLongDate,
   formatShortTime,
   formatTimeToSec,
   timeDifference,


### PR DESCRIPTION
## Description

Removes the unused `formatLongDate` utility and its timezone-fragile test.

`formatLongDate` (`src/ui/utils/formatters.ts`) has **no call sites anywhere in `src/`** — it is dead code — and its unit test asserted the literal `"16 July 2024"` for input `2024-07-16T03:32:59.312000+00:00`. Because `formatLongDate` renders in the machine's *local* zone (`toLocaleDateString` with no `timeZone`), that literal only holds in UTC/positive-offset zones, so `npm test` fails in negative-offset zones (e.g. `"15 July 2024"` in UTC−6) on contributors' machines and CI runners not fixed to UTC.

Rather than pin the Jest timezone — which would only mask the local-zone dependence, and applied suite-wide could hide genuine timezone bugs in the formatters that *are* used — this removes the unused function, its export, and its test.

**No production behavior changes.** The app's other date/time formatters intentionally display local time annotated with a UTC offset (`getUTCOffset`), and are untouched.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [#1667](https://github.com/cardano-foundation/veridian-wallet/issues/1667)

Fixes #1667

### Testing & Validation

- [x] Confirmed `formatLongDate` has no references in `src/`, and ran the formatters spec in a negative-UTC-offset zone (`America/Denver`, UTC−6) on Node 20 — suite green after the removal, with no `TZ` pinning.
- [ ] iOS / Android / browser validation — N/A (removes unused code; no app behavior changes).
- [ ] Added new unit tests — N/A (removes an unused function and its test).

### Design Review

- [ ] N/A — no UI changes.
