### PR TITLE
test: fix flaky unit tests (async races, dead assertions, timeouts)

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -49,4 +49,5 @@ export default {
   },
   setupFilesAfterEnv: ["jest-canvas-mock", "<rootDir>/src/setupTests.ts"],
   setupFiles: ["<rootDir>/src/ui/__mocks__/swiper.tsx"],
+  testTimeout: 15000,
 };

--- a/src/ui/components/ConnectdApp/ConnectdApp.test.tsx
+++ b/src/ui/components/ConnectdApp/ConnectdApp.test.tsx
@@ -490,7 +490,7 @@ describe("Wallet connect", () => {
       expect(getByText(EN_TRANSLATIONS.verifypasscode.title)).toBeVisible();
     });
 
-    passcodeFiller(getByText, getByTestId, "193212");
+    await passcodeFiller(getByText, getByTestId, "193212");
 
     await waitFor(() => {
       expect(dispatchMock).toBeCalledWith(
@@ -559,7 +559,7 @@ describe("Wallet connect", () => {
       expect(getByText(EN_TRANSLATIONS.verifypasscode.title)).toBeVisible();
     });
 
-    passcodeFiller(getByText, getByTestId, "193212");
+    await passcodeFiller(getByText, getByTestId, "193212");
 
     await waitFor(() => {
       expect(dispatchMock).toBeCalledWith(

--- a/src/ui/components/CreatePasscodeModule/CreatePasscodeModule.test.tsx
+++ b/src/ui/components/CreatePasscodeModule/CreatePasscodeModule.test.tsx
@@ -186,17 +186,17 @@ describe("SetPasscode Page", () => {
 
     await passcodeFiller(getByText, getByTestId, "193214");
 
-    await waitFor(
-      () =>
-        expect(queryByText(EN_TRANSLATIONS.createpasscodemodule.errornomatch))
-          .toBeVisible
+    await waitFor(() =>
+      expect(
+        queryByText(EN_TRANSLATIONS.createpasscodemodule.errornomatch)
+      ).toBeVisible()
     );
   });
 
   test("Entering an existing passcode returns an error", async () => {
     verifySecretMock.mockResolvedValue(true);
     require("@ionic/react");
-    const { getByText, queryByText, getByTestId } = render(
+    const { getByText, getByTestId } = render(
       <Provider store={storeMocked}>
         <CreatePasscodeModule
           title={EN_TRANSLATIONS.setpasscode.reenterpasscode}
@@ -209,10 +209,10 @@ describe("SetPasscode Page", () => {
 
     await passcodeFiller(getByText, getByTestId, "193213");
 
-    await waitFor(
-      () =>
-        expect(queryByText(EN_TRANSLATIONS.createpasscodemodule.errornomatch))
-          .toBeVisible
+    await waitFor(() =>
+      expect(
+        getByText(EN_TRANSLATIONS.createpasscodemodule.errormatch)
+      ).toBeVisible()
     );
   });
 
@@ -232,10 +232,10 @@ describe("SetPasscode Page", () => {
 
     await passcodeFiller(getByText, getByTestId, "193213");
 
-    await waitFor(
-      () =>
-        expect(queryByText(EN_TRANSLATIONS.createpasscodemodule.repeat))
-          .toBeVisible
+    await waitFor(() =>
+      expect(
+        queryByText(EN_TRANSLATIONS.createpasscodemodule.repeat)
+      ).toBeVisible()
     );
   });
 
@@ -255,10 +255,10 @@ describe("SetPasscode Page", () => {
 
     await passcodeFiller(getByText, getByTestId, "193213");
 
-    await waitFor(
-      () =>
-        expect(queryByText(EN_TRANSLATIONS.createpasscodemodule.consecutive))
-          .toBeVisible
+    await waitFor(() =>
+      expect(
+        queryByText(EN_TRANSLATIONS.createpasscodemodule.consecutive)
+      ).toBeVisible()
     );
   });
 });

--- a/src/ui/components/CredentialDetailModule/CredentialDetailModule.test.tsx
+++ b/src/ui/components/CredentialDetailModule/CredentialDetailModule.test.tsx
@@ -688,7 +688,7 @@ describe("Cred Detail Module - archived", () => {
       expect(getByText(EN_TRANSLATIONS.verifypasscode.title)).toBeVisible();
     });
 
-    passcodeFiller(getByText, getByTestId, "193212");
+    await passcodeFiller(getByText, getByTestId, "193212");
 
     await waitFor(() => {
       expect(markCredentialPendingDeletion).toBeCalled();
@@ -871,7 +871,7 @@ describe("Cred detail - revoked", () => {
       expect(getByText(EN_TRANSLATIONS.verifypasscode.title)).toBeVisible();
     });
 
-    passcodeFiller(getByText, getByTestId, "193212");
+    await passcodeFiller(getByText, getByTestId, "193212");
 
     await waitFor(() => {
       expect(archiveCredential).toBeCalled();

--- a/src/ui/components/ProfileDetailsModal/components/ProfileContent.test.tsx
+++ b/src/ui/components/ProfileDetailsModal/components/ProfileContent.test.tsx
@@ -392,15 +392,18 @@ describe("ProfileContent", () => {
           Promise.reject(new Error(ConnectionService.CANNOT_GET_OOBI))
         )
         .mockImplementationOnce(() => Promise.resolve("oobi-value"));
-      jest.spyOn(window, "setTimeout");
 
       renderComponent();
 
-      await new Promise((resolve) => setTimeout(() => resolve(false), 3000));
-
-      await waitFor(() => {
-        expect(getOobiMock).toBeCalledTimes(3);
-      });
+      // useGetOobi retries with real setTimeout delays of RETRY_TIMES[0] (1s)
+      // then RETRY_TIMES[1] (2.5s), so the 3rd call lands around 3.5s in.
+      // Wait directly on the call count instead of a blind sleep.
+      await waitFor(
+        () => {
+          expect(getOobiMock).toBeCalledTimes(3);
+        },
+        { timeout: 6000 }
+      );
     });
   });
 

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential/ChooseCredential.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/ChooseCredential/ChooseCredential.test.tsx
@@ -471,7 +471,7 @@ describe("Credential request - choose request", () => {
       expect(getByTestId("passcode-button-1")).toBeVisible();
     });
 
-    passcodeFiller(getByText, getByTestId, "193212");
+    await passcodeFiller(getByText, getByTestId, "193212");
 
     await waitFor(() => {
       expect(verifySecretMock).toHaveBeenCalledWith(

--- a/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/CredentialRequest/CredentialRequest.test.tsx
@@ -610,7 +610,7 @@ describe("Credential request: Multisig", () => {
       expect(getByText(EN_TRANSLATIONS.verifypasscode.title)).toBeVisible();
     });
 
-    passcodeFiller(getByText, getByTestId, "193212");
+    await passcodeFiller(getByText, getByTestId, "193212");
 
     await waitFor(() => {
       expect(offerAcdcFromApplyMock).toBeCalled();

--- a/src/ui/pages/NotificationDetails/components/RemoteSignRequest/RemoteSignRequest.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/RemoteSignRequest/RemoteSignRequest.test.tsx
@@ -131,7 +131,7 @@ describe("Receive credential", () => {
       expect(getByText(EN_TRANSLATIONS.verifypasscode.title)).toBeVisible();
     });
 
-    passcodeFiller(getByText, getByTestId, "193212");
+    await passcodeFiller(getByText, getByTestId, "193212");
 
     await waitFor(() => {
       expect(remoteSignMock).toBeCalled();

--- a/src/ui/pages/SetupGroupProfile/components/PendingGroup/PendingGroup.test.tsx
+++ b/src/ui/pages/SetupGroupProfile/components/PendingGroup/PendingGroup.test.tsx
@@ -250,7 +250,7 @@ describe("Pending group", () => {
         expect(getByText(EN_TRANSLATIONS.verifypasscode.title)).toBeVisible();
       });
 
-      passcodeFiller(getByText, getByTestId, "193212");
+      await passcodeFiller(getByText, getByTestId, "193212");
 
       await waitFor(() => {
         expect(markIdentifierPendingDelete).toBeCalled();

--- a/src/ui/pages/SetupGroupProfile/components/SetupConnections/SetupConnections.test.tsx
+++ b/src/ui/pages/SetupGroupProfile/components/SetupConnections/SetupConnections.test.tsx
@@ -436,7 +436,7 @@ describe("Setup Connection", () => {
       expect(getByText(EN_TRANSLATIONS.verifypasscode.title)).toBeVisible();
     });
 
-    passcodeFiller(getByText, getByTestId, "193212");
+    await passcodeFiller(getByText, getByTestId, "193212");
 
     await waitFor(() => {
       expect(markIdentifierPendingDelete).toBeCalled();


### PR DESCRIPTION
## Description

Running the suite repeatedly under constrained CPU surfaced four reliability defects in the tests themselves. All changes are test-only; no production code touched.

- **9 unawaited `passcodeFiller` calls** (8 files): the helper is async (types each digit with a `waitFor` between clicks); without `await` the following assertion races the typing and fails on slow machines with `Expected >= 1, Received 0`. The other 50 call sites already await it.
- **4 dead assertions** in `CreatePasscodeModule.test.tsx`: `.toBeVisible` without the call parens asserts nothing. Activating them exposed one wrong expectation - the test asserted `errornomatch`, but with `verifySecret` resolving true the component renders `errormatch` ("PIN already in use"); the asserted branch was unreachable. Key corrected, all four activated and passing.
- **`testTimeout: 15000`** in `jest.config.ts`: some UI tests chain 9-16 sequential `fireEvent`/`waitFor` round trips (e.g. `VerifySeedPhraseAlert`, `ChangePin`); under CPU load the cumulative render latency crosses the 5000ms default even though no individual step is broken.
- **Real-timer sleep replaced** in `ProfileContent.test.tsx`: a fixed 3s sleep raced `useGetOobi`'s actual retry schedule (1s + 2.5s backoff) with only ~0.5s margin; replaced with a `waitFor` on the exact retry-count condition. The 50ms sleep in `AppWrapper.test.tsx` is deliberately kept - it guards a must-NOT-be-called assertion, which `waitFor` cannot express.

Verification: all 13 touched suites pass (103 tests), `npx tsc --noEmit` clean.

Possible follow-ups, out of scope here: 3 real-timer sleeps in `src/core/agent/records/*` tests (only separate `Date` timestamps) and 2 `forEach(async)` patterns in seed-phrase tests (floating promises).


## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [#1670](https://github.com/cardano-foundation/veridian-wallet/issues/1670)

Fixes #1670

### Testing & Validation

- [x] All 13 touched suites pass locally (103 tests) and `npx tsc --noEmit` is clean.
- [ ] iOS / Android / browser validation - N/A (test-only changes; no app behavior).
- [x] Added new unit tests - N/A as such: activates 4 previously dead assertions and corrects 1 wrong expectation, which increases effective coverage.

### Design Review

- [ ] N/A - no UI changes.

