### PR TITLE
fix(i18n): name the button the connect screen actually shows

### DIFF
--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -418,7 +418,7 @@
       "title": "Connect to Veridian",
       "description": "Veridian Wallet requires connecting to a Cloud Agent. As part of the onboarding process, you need to scan a QR code which establishes a secure connection.",
       "seconddescription": "For more information and to assist with this process, visit our website.",
-      "bottomdescription": "If you’re ready and understand, please click the “Proceed to scan” button. This will open a scanner where you scan the QR code or manually enter the URL.",
+      "bottomdescription": "If you’re ready and understand, please click the “Get connected” button. This will open a scanner where you scan the QR code or manually enter the URL.",
       "buttons": {
         "connected": "Get connected",
         "onboardingdocumentation": "Visit our documentation",


### PR DESCRIPTION
## Description

Closes #1672

The **Connect to Veridian** screen (route `/ssiagent`) tells the user to click a "Proceed to scan" button that does not exist — the primary button is labelled "Get connected". This changes the one locale string so the instruction names the button the user can actually see.

Why the copy and not the button: both strings landed together in `5ba3b412` (#1406), "Proceed to scan" occurs nowhere else in the repository, and "Get connected" is what the e2e suite navigates by. Full reasoning and a screenshot of the defect are in #1672.

One line in `src/locales/en/en.json:421`. `en` is the only locale.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**#1672**](https://github.com/veridian-id/veridian-wallet/issues/1672)

### Testing & Validation

- [ ] This PR has been tested/validated in iOS, Android and browser.
- [ ] Added new unit tests, if relevant.

The defect was reproduced on an Android emulator build at `ed015b1`, and the fix was then run in the browser on this branch — the screenshot below is that run. It has **not** been exercised on iOS or on an Android build, so the box stays unticked. It is a single locale string with no code references and no test asserting it. Happy to validate on the remaining platforms before merge if you would like.

### Design Review

- [x] In case this PR contains changes to the UI, add some screenshots and/or videos to show the changes on relevant devices.

After the change, running this branch — the instruction now names the button that is actually on the screen:

<img src="https://github.com/user-attachments/assets/cfc104da-7f35-4409-99cb-b61056446499" width="35%">

The before screenshot, showing the same screen with the mismatch, is in #1672.
